### PR TITLE
Make specifying OU for computer object optional and updated Readme and Meta files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ linux adbinding
 
 [![Build Status](https://travis-ci.org/ANTS-Framework/linux_adbinding.svg?branch=master)](https://travis-ci.org/ANTS-Framework/linux_adbinding)
 
-Join your linux client to AD using sssd.
+Join your linux client to AD using sssd and realmd.
 
 Role Variables
 --------------
@@ -13,24 +13,17 @@ Role Variables
     linux_adbinding__ou: CN=Computers,DC=ADS,DC=EXAMPLE,DC=ORG
     linux_adbinding__user: bind-user
     linux_adbinding__password: bind-users-password
-    linux_adbinding__dependencies_yum:
-        - sssd
-        - sssd-ad
-        - sssd-client
-        - sssd-common
-        - sssd-common-pac
-        - sssd-krb5
-        - sssd-krb5-common
-        - adcli
-        - krb5-libs
-        - krb5-workstation
-        - pam_krb5
-        - authconfig
-        - oddjob
-        - oddjob-mkhomedir
-    linux_adbinding__dependencies_apt:
-        - sssd
 ```
+
+`linux_adbinding__domain` and `linux_adbinding__ou` are optional.
+
+Realmd can usually discover the AD domain automatically, so the domain should only need to specified if there are more than 1 domain in use or if the discovery process doesn't work.
+
+The OU in which to save the computer object will default to the Computers OU if it is not specified, so this OU should only need to be specified when the computer object needs to be created in a different OU.
+
+`linux_adbinding__user` and `linux_adbinding__password` are mandatory and always needed. It is recommended that these be stored in an ansible vault.
+
+Currently this role cannot remove your client client from AD. To do this, use `sudo realm leave` or `sudo realm leave -U <bind-user>`. If you specify the bind-user credentials this will additionally delete the computer object in AD. If you don't specify this, the workstation will no longer be bound however the computer object will remain in AD.
 
 Example Playbook
 ----------------
@@ -42,6 +35,15 @@ Example Playbook
         - linux_adbinding__ou: CN=Computers,DC=ADS,DC=EXAMPLE,DC=ORG
         - linux_adbinding__user: bind-user
         - linux_adbinding__password: bind-users-password
+      roles:
+        - linux_adbinding
+```
+
+or store the credentials in a vault and leave domain and ou as unspecified:
+
+```yml
+    - hosts: clients
+      vars_files: linux_adbinding_vault.yml
       roles:
         - linux_adbinding
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-    linux_adbinding__ou: CN=Computers,DC=ADS,DC=EXAMPLE,DC=ORG
     linux_adbinding__user: bind-user
     linux_adbinding__password: bind-users-password
     linux_adbinding__dependencies_yum:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author: Jan Welker
-  description: Join your linux client to AD using sssd
+  description: Join your linux client to AD using sssd and realmd
   company: IT Services University of Basel
   license: GPLv3
   min_ansible_version: 2.3.2.0
@@ -14,6 +14,11 @@ galaxy_info:
     - ansiblePull
     - unibas
     - linux
+    - activedirectory
+    - ad
+    - binding
+    - sssd
+    - realmd
 
     #
     # NOTE: A tag is limited to a single word comprised of alphanumeric characters.

--- a/templates/realmd.conf.j2
+++ b/templates/realmd.conf.j2
@@ -7,6 +7,7 @@ default-home = /home/%u
 default-shell = /bin/bash
 
 [{{ linux_adbinding__domain }}]
-computer-ou = {{ linux_adbinding__ou }}
+{% if linux_adbinding__ou is defined %}computer-ou = {{ linux_adbinding__ou }}
+{% endif %}
 fully-qualified-names = no
 automatic-id-mapping = no


### PR DESCRIPTION
Hi,

Just one more general improvement to make specifying the OU for the computer object to be saved in optional. If this is not specified the standard "Computers" OU will be used.

I've updated the README.md file a little and also the meta/main.yml file to include reference to Realmd and added some tags I thought might be useful.

Happy for any recommendations you have with the README or meta tags.

Cheers.